### PR TITLE
ページネーション機能追加

### DIFF
--- a/src/__pages_test__/user/lessons/index.test.tsx
+++ b/src/__pages_test__/user/lessons/index.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import {render} from '@testing-library/react';
-import Lessons from '../../../pages/user/lessons';
+import React from "react";
+import { render } from "@testing-library/react";
+import Lessons from "../../../pages/user/lessons";
 
-describe('Lessons', () => {
-  test('コンポーネントをレンダリングすること', () => {
+describe("Lessons", () => {
+  test("コンポーネントをレンダリングすること", () => {
     render(<Lessons />);
   });
 });

--- a/src/apis/models/pagination.ts
+++ b/src/apis/models/pagination.ts
@@ -1,0 +1,3 @@
+export type Pagination = {
+  is_last_page: boolean;
+};

--- a/src/components/common/Pagination.test.tsx
+++ b/src/components/common/Pagination.test.tsx
@@ -1,0 +1,52 @@
+import {render} from '@testing-library/react';
+import {Pagination} from './Pagination';
+
+const onClick = () => console.log('click');
+
+describe('Pagination', () => {
+  test('isFirstPageがfalseの場合', () => {
+    const {container} = render(
+        <Pagination
+          isFirstPage={false}
+          isLastPage={true}
+          onPageBack={onClick}
+          onPageNext={onClick}
+        />,
+    );
+    const buttons = container.getElementsByTagName('button');
+
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent).toBe('前へ');
+  });
+
+  test('isFirstPageとisLastPageがfalseの場合', () => {
+    const {container} = render(
+        <Pagination
+          isFirstPage={false}
+          isLastPage={false}
+          onPageBack={onClick}
+          onPageNext={onClick}
+        />,
+    );
+    const buttons = container.getElementsByTagName('button');
+
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].textContent).toBe('前へ');
+    expect(buttons[1].textContent).toBe('次へ');
+  });
+
+  test('isLastPageがfalseの場合', () => {
+    const {container} = render(
+        <Pagination
+          isFirstPage={true}
+          isLastPage={false}
+          onPageBack={onClick}
+          onPageNext={onClick}
+        />,
+    );
+    const buttons = container.getElementsByTagName('button');
+
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent).toBe('次へ');
+  });
+});

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  onPageBack: () => void;
+  onPageNext: () => void;
+};
+
+export const Pagination = ({
+  isFirstPage,
+  isLastPage,
+  onPageBack,
+  onPageNext,
+}: Props) => {
+  return (
+    <div className="flex justify-center items-center">
+      {!isFirstPage && (
+        <button className="border-2 m-2 p-1" onClick={onPageBack}>
+          前へ
+        </button>
+      )}
+      {!isLastPage && (
+        <button className="border-2 m-2 p-1" onClick={onPageNext}>
+          次へ
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/pages/user/lessons/Lessons/LessonCard.test.tsx
+++ b/src/components/pages/user/lessons/Lessons/LessonCard.test.tsx
@@ -1,31 +1,31 @@
-import {render, screen} from '@testing-library/react';
-import {Lesson} from '../../../../../apis/models/lesson';
-import {LessonCard} from './LessonCard';
+import { render, screen } from "@testing-library/react";
+import { Lesson } from "../../../../../apis/models/lesson";
+import { LessonCard } from "./LessonCard";
 
 const lesson: Lesson = {
   id: 1,
-  title: 'title',
+  title: "title",
   price: 1000,
-  category: 'yoga',
+  category: "yoga",
   time: 50,
-  content: 'content',
+  content: "content",
 };
 
-describe('LessonCard', () => {
-  test('コンポーネントをレンダリングすること', () => {
+describe("LessonCard", () => {
+  test("コンポーネントをレンダリングすること", () => {
     render(<LessonCard lesson={lesson} />);
 
-    expect(screen.getByRole('img')).toHaveAttribute('src', '/sample.jpg');
-    const {container} = render(<LessonCard lesson={lesson} />);
-    const paragraphs = container.getElementsByTagName('p');
-    const contents = container.getElementsByTagName('span');
+    expect(screen.getByRole("img")).toHaveAttribute("src", "/sample.jpg");
+    const { container } = render(<LessonCard lesson={lesson} />);
+    const paragraphs = container.getElementsByTagName("p");
+    const contents = container.getElementsByTagName("span");
 
     expect(paragraphs.length).toBe(2);
     expect(paragraphs[0].textContent).toBe(lesson.title);
     expect(paragraphs[1].textContent).toBe(
-        `${lesson.price}円/${lesson.time}min`,
+      `${lesson.price}円/${lesson.time}min`
     );
     expect(contents.length).toBe(1);
-    expect(contents[0].textContent).toBe('ヨガ');
+    expect(contents[0].textContent).toBe("ヨガ");
   });
 });

--- a/src/components/pages/user/lessons/Lessons/LessonCard.tsx
+++ b/src/components/pages/user/lessons/Lessons/LessonCard.tsx
@@ -1,11 +1,11 @@
-import Link from 'next/link';
-import {Lesson} from '../../../../../apis/models/lesson';
-import {categoryBy} from '../../../../../utils/categoryBy';
+import Link from "next/link";
+import { Lesson } from "../../../../../apis/models/lesson";
+import { categoryBy } from "../../../../../utils/categoryBy";
 
 type Props = {
   lesson: Lesson;
 };
-export const LessonCard = ({lesson}: Props) => {
+export const LessonCard = ({ lesson }: Props) => {
   return (
     <Link href={`/user/lesson/${lesson.id}`}>
       <a className="w-3/6">

--- a/src/components/pages/user/lessons/Lessons/index.test.tsx
+++ b/src/components/pages/user/lessons/Lessons/index.test.tsx
@@ -1,21 +1,21 @@
-import {render, screen} from '@testing-library/react';
-import {Lessons} from '.';
+import { render, screen } from "@testing-library/react";
+import { Lessons } from ".";
 
 const lessons = [
   {
     id: 1,
-    title: 'title',
+    title: "title",
     price: 1000,
-    category: 'yoga',
+    category: "yoga",
     time: 50,
-    content: 'content',
+    content: "content",
   },
 ];
 
-describe('Lessons', () => {
-  test('コンポーネントをレンダリングすること', () => {
+describe("Lessons", () => {
+  test("コンポーネントをレンダリングすること", () => {
     render(<Lessons lessons={lessons} />);
 
-    expect(screen.getByText('レッスン一覧')).toBeTruthy();
+    expect(screen.getByText("レッスン一覧")).toBeTruthy();
   });
 });

--- a/src/hooks/user/useLessons.ts
+++ b/src/hooks/user/useLessons.ts
@@ -1,14 +1,22 @@
-import useSWR from "swr";
-import { fetcher } from "../../apis/client";
-import { Lesson } from "../../apis/models/lesson";
-import { BaseType } from "../type";
+import useSWR from 'swr';
+import {fetcher} from '../../apis/client';
+import {Lesson} from '../../apis/models/lesson';
+import {Pagination} from '../../apis/models/pagination';
+import {BaseType} from '../type';
 
-export const useLessons = () => {
-  const { data, error } = useSWR(`/api/v1/user/lessons`, fetcher);
+type LessonsResponse = {
+  lessons: Lesson[];
+} & Pagination;
+
+export const useLessons = (pageIndex: number) => {
+  const {data, error} = useSWR(
+      `/api/v1/user/lessons?page=${pageIndex}`,
+      fetcher,
+  );
   return {
-    data: data?.data?.lessons,
+    data: data?.data,
     error: data?.error,
     isLoading: !error && !data,
     isError: error,
-  } as BaseType<Lesson[]>;
+  } as BaseType<LessonsResponse>;
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,8 @@
-import '../styles/globals.css';
-import Head from 'next/head';
-import {GlobalNav} from '../components/common/GlobalNav';
+import "../styles/globals.css";
+import Head from "next/head";
+import { GlobalNav } from "../components/common/GlobalNav";
 
-const MyApp = ({Component, pageProps}) => {
+const MyApp = ({ Component, pageProps }) => {
   return (
     <>
       <Head>

--- a/src/pages/user/lessons/index.tsx
+++ b/src/pages/user/lessons/index.tsx
@@ -1,9 +1,12 @@
 import {useLessons} from '../../../hooks/user/useLessons';
 import {Lessons as LessonList} from
   '../../../components/pages/user/lessons/Lessons';
+import {Pagination} from '../../../components/common/Pagination';
+import {useState} from 'react';
 
 const Lessons = () => {
-  const {data: lessons, error, isLoading, isError} = useLessons();
+  const [pageIndex, setPageIndex] = useState(1);
+  const {data, error, isLoading, isError} = useLessons(pageIndex);
 
   if (isError) return <p className="pt-32">Failed to load</p>;
   if (error) return <p className="pt-32">{error}</p>;
@@ -11,7 +14,19 @@ const Lessons = () => {
   return (
     <div className="h-screen w-2/3 mx-auto">
       <div className="pt-32">
-        {isLoading ? <p>Loading...</p> : <LessonList lessons={lessons} />}
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : (
+          <div>
+            <LessonList lessons={data.lessons} />
+            <Pagination
+              isFirstPage={pageIndex === 1}
+              isLastPage={data.is_last_page}
+              onPageBack={() => setPageIndex(pageIndex - 1)}
+              onPageNext={() => setPageIndex(pageIndex + 1)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 1. 実装内容
- 「次へ」「前へ」ボタンを押すとその前後のページに遷移する
- 最初のページには「次へ」ボタンのみ
- 最後のページには「前へ」ボタンのみ  
---

## 2. スクリーンショット（UI を変更した場合のみ）

<img src="" width="">
https://gyazo.com/8a8154e18075a73bda3e8ee8554a08ce
---

## 3. Checklist

- [x] 動作確認したこと
- [ ] 追加/更新した箇所のテストを追加/修正したこと
- [x] ローカルで Eslint が通っていること
- [ ] ローカルで Jest が通っていること

---

## 4. 保留にした TODO（あれば）

---

## 5. その他（参考にした記事などあれば）
